### PR TITLE
Fix disregard of `commonmarkOptions` parameter 

### DIFF
--- a/docs/using-the-blade-component/passing-options-to-commonmark.md
+++ b/docs/using-the-blade-component/passing-options-to-commonmark.md
@@ -8,7 +8,7 @@ Under the hood, the `league/commonmark` package is used to render markdown. In t
 If you want to pass options to be used by a particular instance of `x-markdown`, you can pass options to the `options` attribute.
 
 ```html
-<x-markdown :options="['enable_strong' => false]">
+<x-markdown :options="['commonmark' => ['enable_strong' => false]]">
 # My title
 </x-markdown>
 ```

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -156,5 +156,7 @@ class MarkdownRenderer
         foreach ($this->inlineRenders as $inlineRenderer) {
             $environment->addInlineRenderer($inlineRenderer['class'], $inlineRenderer['renderer']);
         }
+        
+        $environment->mergeConfig($this->commonmarkOptions);
     }
 }


### PR DESCRIPTION
without this change, the `commonmarkOptions` parameter documented [here](https://spatie.be/docs/laravel-markdown/v1/using-the-blade-component/passing-options-to-commonmark) has no effect.
I assumed that all options on this page should be exposed and updated the example accordingly.