### PR TITLE
Set secure defaults for html escaping

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -31,6 +31,28 @@ return [
     'commonmark_options' => [],
 
     /*
+     * Allow HTML elements in your markdown to be passed on.
+     * Only enable you either
+     *   - escape your markdown before it enters the component
+     *     (e.g. by using {{}} for the price of incorrect rendering of blockquotes)
+     *   - or do not render any user-supplied markdown
+     *
+     * More info: https://spatie.be/docs/laravel-markdown/v1/security
+     */
+    'allowHTML' => false,
+
+    /*
+     * Allow links to contain Javascript (e.g. [link](javascript:window.alert('hello')))
+     * Only enable you either
+     *   - escape your markdown before it enters the component
+     *     (e.g. by using {{}} for the price of incorrect rendering of blockquotes)
+     *   - or do not render any user-supplied markdown
+     *
+     * More info: https://spatie.be/docs/laravel-markdown/v1/security
+     */
+    'allowUnsafeLinks' => false,
+
+    /*
      * Rendering markdown to HTML can be resource intensive. By default
      * we'll cache the results.
      *

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -1,11 +1,11 @@
 ---
 title: About us
-weight: 9
+weight: 10
 ---
 
 [Spatie](https://spatie.be) is a webdesign agency based in Antwerp, Belgium.
 
-Open source software is used in all projects we deliver. Laravel, Nginx, Ubuntu are just a few 
-of the free pieces of software we use every single day. For this, we are very grateful. 
-When we feel we have solved a problem in a way that can help other developers, 
+Open source software is used in all projects we deliver. Laravel, Nginx, Ubuntu are just a few
+of the free pieces of software we use every single day. For this, we are very grateful.
+When we feel we have solved a problem in a way that can help other developers,
 we release our code as open source software [on GitHub](https://spatie.be/open-source).

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -62,6 +62,28 @@ return [
     'commonmark_options' => [],
 
     /*
+     * Allow HTML elements in your markdown to be passed on.
+     * Only enable you either
+     *   - escape your markdown before it enters the component
+     *     (e.g. by using {{}} for the price of incorrect rendering of blockquotes)
+     *   - or do not render any user-supplied markdown
+     *
+     * More info: https://spatie.be/docs/laravel-markdown/v1/security
+     */
+    'allowHTML' => false,
+
+    /*
+     * Allow links to contain Javascript (e.g. [link](javascript:window.alert('hello')))
+     * Only enable you either
+     *   - escape your markdown before it enters the component
+     *     (e.g. by using {{}} for the price of incorrect rendering of blockquotes)
+     *   - or do not render any user-supplied markdown
+     *
+     * More info: https://spatie.be/docs/laravel-markdown/v1/security
+     */
+    'allowUnsafeLinks' => false,
+
+    /*
      * Rendering markdown to HTML can be resource intensive. By default
      * we'll cache the results.
      *
@@ -112,4 +134,3 @@ return [
     ],
 ];
 ```
-

--- a/docs/questions-issues.md
+++ b/docs/questions-issues.md
@@ -3,6 +3,6 @@ title: Questions and issues
 weight: 5
 ---
 
-Find yourself stuck using the package? Found a bug? Do you have general questions or suggestions for improving Laravel Event Sourcing? Feel free to [create an issue on GitHub](https://github.com/spatie/laravel-markdown/issues), we'll try to address it as soon as possible.
+Find yourself stuck using the package? Found a bug? Do you have general questions or suggestions for improving Laravel Event Sourcing? Feel free to [open a thread on GitHub](https://github.com/spatie/laravel-markdown/discussions), we'll try to address it as soon as possible.
 
 If you've found a bug regarding security please mail [freek@spatie.be](mailto:freek@spatie.be) instead of using the issue tracker.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,34 @@
+---
+title: Security & HTML Escaping
+weight: 9
+---
+
+By default, we assume that you are using this component to render user-supplied content.
+
+To prevent reflected cross-site-scripting attacks which can be caused by the user adding script tags or javascript links, all HTML elements and unsafe links will be stripped from your markdown and not rendered.
+
+If you are supplying the markdown yourself and know what you are doing, you can disable this behaviour either in the config or by passing the corresponding options to the blade component:
+
+```blade
+<x-markdown allowHTML="true" allowUnsafeLinks="true">
+I actually want to render some HTML supplied by myself:
+<table style="width:100%">
+ <tr>
+   <th>Firstname</th>
+   <th>Lastname</th>
+   <th>Age</th>
+ </tr>
+ <tr>
+   <td>Jill</td>
+   <td>Smith</td>
+   <td>50</td>
+ </tr>
+ <tr>
+   <td>Eve</td>
+   <td>Jackson</td>
+   <td>94</td>
+ </tr>
+</table>
+[Alert me!](javascript:window.alert('hello!'))
+</x-markdown>
+```

--- a/docs/using-the-blade-component/general-usage.md
+++ b/docs/using-the-blade-component/general-usage.md
@@ -31,3 +31,9 @@ echo 'Hello world';
 <span class="line"></span></code></pre>
 </div>
 ```
+
+If you are rendering dynamic content, you need to pass it unescaped to the component, or block quote rendering will not work. Do not worry, in the standard configuration, any HTML or unsafe links will be removed.
+
+```blade
+<x-markdown>{!!$unescaped_content!!}</x-markdown>
+```

--- a/src/MarkdownBladeComponent.php
+++ b/src/MarkdownBladeComponent.php
@@ -12,6 +12,8 @@ class MarkdownBladeComponent extends Component
         protected ?bool $highlightCode = null,
         protected ?string $theme = null,
         protected ?bool $anchors = null,
+        protected ?bool $allowHTML = null,
+        protected ?bool $allowUnsafeLinks = null
     ) {
     }
 
@@ -27,6 +29,8 @@ class MarkdownBladeComponent extends Component
             renderAnchors: $this->anchors ?? $config['add_anchors_to_headings'],
             blockRenderers: $config['block_renderers'],
             inlineRenders: $config['inline_renderers'],
+            allowHTML: $this->allowHTML ?? config['allowHTML'],
+            allowUnsafeLinks: $this->allowUnsafeLinks ?? config['allowUnsafeLinks'],
         );
 
         return $markdownRenderer->toHtml($markdown);

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -23,6 +23,8 @@ class MarkdownRenderer
         protected array $extensions = [],
         protected array $blockRenderers = [],
         protected array $inlineRenders = [],
+        protected bool $allowHTML = false,
+        protected bool $allowUnsafeLinks = false,
     ) {
     }
 
@@ -156,5 +158,12 @@ class MarkdownRenderer
         foreach ($this->inlineRenders as $inlineRenderer) {
             $environment->addInlineRenderer($inlineRenderer['class'], $inlineRenderer['renderer']);
         }
+
+        $securityOptions = [
+          'html' => $this->allowHTML ? 'allow' : 'strip',
+          'allow_unsafe_links' => $this->allowUnsafeLinks
+        ];
+
+        $environment.mergeConfig($securityOptions);
     }
 }

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -27,7 +27,9 @@ class MarkdownServiceProvider extends PackageServiceProvider
                 highlightTheme: $config['code_highlighting']['theme'],
                 cacheStoreName: $config['cache_store'],
                 renderAnchors: $config['add_anchors_to_headings'],
-                extensions: $config['extensions']
+                extensions: $config['extensions'],
+                allowHTML: $config['allowHTML'],
+                allowUnsafeLinks: $config['allowUnsafeLinks'],
             );
 
             foreach ($config['block_renderers'] as $blockRenderer) {


### PR DESCRIPTION
User-supplied content needs to be passed into the blade component unescaped, otherwise blockquotes which use `>` will not work correctly. 
This PR aims to set secure defaults that prevent [reflected XSS attacks](https://owasp.org/www-community/attacks/xss/).