### PR TITLE
Use spatie/commonmark-shiki-highlighter 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/contracts": "^8.37",
         "illuminate/support": "^8.49",
         "illuminate/view": "^8.49",
-        "spatie/commonmark-shiki-highlighter": "^1.1",
+        "spatie/commonmark-shiki-highlighter": "^2.0",
         "spatie/laravel-package-tools": "^1.4.3"
     },
     "require-dev": {

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -54,7 +54,7 @@ return [
      * These extensions should be added to the markdown environment. An valid
      * extension implements League\CommonMark\Extension\ExtensionInterface
      *
-     * More info: https://commonmark.thephpleague.com/1.6/extensions/overview/
+     * More info: https://commonmark.thephpleague.com/2.0/extensions/overview/
      */
     'extensions' => [
         //
@@ -64,7 +64,7 @@ return [
      * These block renderers should be added to the markdown environment. An valid
      * renderer implements League\CommonMark\Block\Renderer\BlockRendererInterface;
      *
-     * More info: https://commonmark.thephpleague.com/1.6/customization/block-rendering/
+     * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
     'block_renderers' => [
         // ['blockClass' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer()]

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -51,7 +51,7 @@ return [
     'renderer_class' => Spatie\LaravelMarkdown\MarkdownRenderer::class,
 
     /*
-     * These extensions should be added to the markdown environment. An valid
+     * These extensions should be added to the markdown environment. A valid
      * extension implements League\CommonMark\Extension\ExtensionInterface
      *
      * More info: https://commonmark.thephpleague.com/2.0/extensions/overview/
@@ -61,8 +61,8 @@ return [
     ],
 
     /*
-     * These block renderers should be added to the markdown environment. An valid
-     * renderer implements League\CommonMark\Block\Renderer\BlockRendererInterface;
+     * These block renderers should be added to the markdown environment. A valid
+     * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
      *
      * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
@@ -71,11 +71,11 @@ return [
     ],
 
     /*
-     * These inline renderers should be added to the markdown environment. An valid
-     * renderer implements League\CommonMark\Block\Renderer\InlineRendererInterface;
- *
- * More info: https://commonmark.thephpleague.com/1.6/customization/inline-rendering/
- */
+     * These inline renderers should be added to the markdown environment. A valid
+     * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
+     */
     'inline_renderers' => [
         // ['blockClass' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer()]
     ],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "author": "Spatie",
     "license": "MIT",
     "dependencies": {
-        "shiki": "^0.9.5"
+        "shiki": "^0.9.10"
     }
 }

--- a/src/MarkdownBladeComponent.php
+++ b/src/MarkdownBladeComponent.php
@@ -27,7 +27,7 @@ class MarkdownBladeComponent extends Component
             renderAnchors: $this->anchors ?? $config['add_anchors_to_headings'],
             extensions: $config['extensions'],
             blockRenderers: $config['block_renderers'],
-            inlineRenders: $config['inline_renderers'],
+            inlineRenderers: $config['inline_renderers'],
         );
 
         return $markdownRenderer->toHtml($markdown);

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -146,7 +146,7 @@ class MarkdownRenderer
         }
 
         foreach ($this->extensions as $extension) {
-            $environment->addExtension($extension);
+            $environment->addExtension(new $extension());
         }
 
         foreach ($this->blockRenderers as $blockRenderer) {

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -21,20 +21,16 @@ class MarkdownServiceProvider extends PackageServiceProvider
             $config = config('markdown');
 
             /** @var \Spatie\LaravelMarkdown\MarkdownRenderer $renderer */
-            $renderer = new $config['renderer_class'](
+            return new $config['renderer_class'](
                 commonmarkOptions: $config['commonmark_options'],
                 highlightCode: $config['code_highlighting']['enabled'],
                 highlightTheme: $config['code_highlighting']['theme'],
                 cacheStoreName: $config['cache_store'],
                 renderAnchors: $config['add_anchors_to_headings'],
-                extensions: $config['extensions']
+                extensions: $config['extensions'],
+                blockRenderers: $config['block_renderers'],
+                inlineRenderers: $config['inline_renderers'],
             );
-
-            foreach ($config['block_renderers'] as $blockRenderer) {
-                $renderer->addBlockRenderer($blockRenderer['class'], $blockRenderer['renderer']);
-            }
-
-            return $renderer;
         });
     }
 }

--- a/src/Renderers/AnchorHeadingRenderer.php
+++ b/src/Renderers/AnchorHeadingRenderer.php
@@ -3,16 +3,20 @@
 namespace Spatie\LaravelMarkdown\Renderers;
 
 use Illuminate\Support\Str;
-use League\CommonMark\Block\Element\AbstractBlock;
-use League\CommonMark\Block\Renderer\BlockRendererInterface;
-use League\CommonMark\ElementRendererInterface;
-use League\CommonMark\HtmlElement;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
 
-class AnchorHeadingRenderer implements BlockRendererInterface
+class AnchorHeadingRenderer implements NodeRendererInterface
 {
-    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, $inTightList = false)
+    /**
+     * @param Node|Heading $node
+     */
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
     {
-        $element = $this->createElement($block, $htmlRenderer);
+        $element = $this->createElement($node, $childRenderer);
 
         $id = Str::slug($element->getContents());
 
@@ -21,12 +25,16 @@ class AnchorHeadingRenderer implements BlockRendererInterface
         return $element;
     }
 
-    protected function createElement(AbstractBlock $block, ElementRendererInterface $htmlRenderer): HtmlElement
+    /**
+     * @param Node|Heading $node
+     */
+    protected function createElement(Node $node, ChildNodeRendererInterface $childRenderer): HtmlElement
     {
-        $tag = "h{$block->getLevel()}";
+        $tagName = "h{$node->getLevel()}";
 
-        $attrs = $block->getData('attributes', []);
+        $attrs = $node->data->get('attributes', []);
 
-        return new HtmlElement($tag, $attrs, $htmlRenderer->renderInlines($block->children()));
+        return new HtmlElement($tagName, $attrs, $childRenderer->renderNodes($node->children()));
     }
+
 }

--- a/tests/__snapshots__/MarkdownBladeComponentTest__the_component_can_render_markdown__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__the_component_can_render_markdown__1.txt
@@ -1,5 +1,5 @@
 <div ><h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #fff"><code><span class="line"><span style="color: #005CC5">echo</span><span style="color: #24292E"> </span><span style="color: #032F62">&#39;Hello world&#39;</span><span style="color: #24292E">;</span></span>
+<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #005CC5">echo</span><span style="color: #24292E"> </span><span style="color: #032F62">&#39;Hello world&#39;</span><span style="color: #24292E">;</span></span>
 <span class="line"></span></code></pre>
 </div>

--- a/tests/__snapshots__/MarkdownBladeComponentTest__the_component_can_use_a_custom_theme__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__the_component_can_use_a_custom_theme__1.txt
@@ -1,3 +1,3 @@
-<div ><pre class="shiki" style="background-color: #24292e"><code><span class="line"><span style="color: #79B8FF">echo</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">&#39;Hello world&#39;</span><span style="color: #E1E4E8">;</span></span>
+<div ><pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"></span></code></pre>
 </div>

--- a/tests/__snapshots__/MarkdownBladeComponentTest__the_default_theme_can_be_set_in_the_config_file__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__the_default_theme_can_be_set_in_the_config_file__1.txt
@@ -1,3 +1,3 @@
-<div ><pre class="shiki" style="background-color: #24292e"><code><span class="line"><span style="color: #79B8FF">echo</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">&#39;Hello world&#39;</span><span style="color: #E1E4E8">;</span></span>
+<div ><pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"></span></code></pre>
 </div>

--- a/tests/__snapshots__/MarkdownRendererTest__it_can_render_markdown__1.txt
+++ b/tests/__snapshots__/MarkdownRendererTest__it_can_render_markdown__1.txt
@@ -1,4 +1,4 @@
 <h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #fff"><code><span class="line"><span style="color: #005CC5">echo</span><span style="color: #24292E"> </span><span style="color: #032F62">&#39;Hello world&#39;</span><span style="color: #24292E">;</span></span>
+<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #005CC5">echo</span><span style="color: #24292E"> </span><span style="color: #032F62">&#39;Hello world&#39;</span><span style="color: #24292E">;</span></span>
 <span class="line"></span></code></pre>

--- a/tests/__snapshots__/MarkdownRendererTest__it_can_use_an_alternative_highlighting_them__1.txt
+++ b/tests/__snapshots__/MarkdownRendererTest__it_can_use_an_alternative_highlighting_them__1.txt
@@ -1,4 +1,4 @@
 <h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #24292e"><code><span class="line"><span style="color: #79B8FF">echo</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">&#39;Hello world&#39;</span><span style="color: #E1E4E8">;</span></span>
+<pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
 <span class="line"></span></code></pre>


### PR DESCRIPTION
This update accounts for changes made in the `spatie/commonmark-shiki-highlighter` as well as those further upstream in `League\CommonMark` 2.0 as that had some significant ones. The other change this accounts for is that Shiki upstream changed color schemes to keep current with their sources too.