### PR TITLE
Enable use of RenderedContentInterface and small fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "scripts": {
         "test": "./vendor/bin/testbench package:test --parallel --no-coverage",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {
         "sort-packages": true

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -125,9 +125,7 @@ class MarkdownRenderer
 
     protected function convertMarkdownToHtml(string $markdown): string
     {
-        $commonMarkConverter = $this->getMarkdownConverter();
-
-        return $commonMarkConverter->convertToHtml($markdown);
+        return $this->getMarkdownConverter()->convertToHtml($markdown);
     }
 
     protected function configureCommonMarkEnvironment(EnvironmentBuilderInterface $environment): void

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -142,7 +142,10 @@ class MarkdownRenderer
         }
 
         foreach ($this->extensions as $extension) {
-            $environment->addExtension(new $extension());
+            if (is_string($extension) && class_exists($extension)) {
+                $extension = new $extension();
+            }
+            $environment->addExtension($extension);
         }
 
         foreach ($this->blockRenderers as $blockRenderer) {

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -8,6 +8,7 @@ use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\ExtensionInterface;
 use League\CommonMark\MarkdownConverter;
+use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 use Spatie\CommonMarkShikiHighlighter\HighlightCodeExtension;
 use Spatie\LaravelMarkdown\Renderers\AnchorHeadingRenderer;
@@ -124,12 +125,7 @@ class MarkdownRenderer
 
     protected function convertMarkdownToHtml(string $markdown): string
     {
-        $environment = new Environment($this->commonmarkOptions);
-        $this->configureCommonMarkEnvironment($environment);
-
-        $commonMarkConverter = new MarkdownConverter(
-            environment: $environment
-        );
+        $commonMarkConverter = $this->getMarkdownConverter();
 
         return $commonMarkConverter->convertToHtml($markdown);
     }
@@ -156,5 +152,20 @@ class MarkdownRenderer
         foreach ($this->inlineRenderers as $inlineRenderer) {
             $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer']);
         }
+    }
+
+    private function getMarkdownConverter(): MarkdownConverter
+    {
+        $environment = new Environment($this->commonmarkOptions);
+        $this->configureCommonMarkEnvironment($environment);
+
+        return new MarkdownConverter(
+            environment: $environment
+        );
+    }
+
+    public function convertToHtml(string $markdown): RenderedContentInterface
+    {
+        return $this->getMarkdownConverter()->convertToHtml($markdown);
     }
 }

--- a/tests/MarkdownFrontMatterRendererTest.php
+++ b/tests/MarkdownFrontMatterRendererTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Spatie\LaravelMarkdown\Tests;
+
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
+use Spatie\LaravelMarkdown\MarkdownRenderer;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class MarkdownFrontMatterRendererTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    /** @test */
+    public function it_can_use_front_matter_extensions()
+    {
+        config()->set('markdown.extensions', [
+            FrontMatterExtension::class,
+        ]);
+
+        $markdown     = <<<EOT
+---
+extends: post
+title: My title
+---
+# My title
+
+This is a [link to our website](https://spatie.be)
+
+```php
+echo 'Hello world';
+```
+EOT;
+
+        $renderedMarkdown = $this
+           ->markdownRenderer()
+           ->convertToHtml($markdown);
+        $this->assertInstanceOf(RenderedContentWithFrontMatter::class, $renderedMarkdown);
+
+        $frontMatter = $renderedMarkdown->getFrontMatter();
+        $this->assertEquals([
+            'extends' => 'post',
+            'title' => 'My title',
+        ], $frontMatter);
+        $html = $renderedMarkdown->getContent();
+        $this->assertMatchesSnapshot($html);
+    }
+
+    /** @test */
+    public function it_can_parse_many_front_matter_variables()
+    {
+        // Add the extension on the fly to ensure addExtension is covered by tests too.
+        $markdownRenderer = $this->markdownRenderer()->addExtension(new FrontMatterExtension());
+
+        $markdown     = <<<EOT
+---
+title: Using FrontMatter with Laravel Blade
+description: How to render FrontMatter & Blade with Spatie Markdown
+extends: layouts.documentation
+section: content
+food: Pizza
+---
+# Using FrontMatter with Laravel Blade
+
+This is a [link to our website](https://spatie.be).
+
+The content here would be rendered by markdown first - then you would get the FrontMatter metadata and render it again.
+This time by rendering the template defined in extends, and the HTML content rendered by markdown into the defined section.
+EOT;
+
+        $renderedMarkdown = $markdownRenderer
+            ->convertToHtml($markdown);
+        $this->assertInstanceOf(RenderedContentWithFrontMatter::class, $renderedMarkdown);
+
+        $frontMatter = $renderedMarkdown->getFrontMatter();
+        $this->assertEquals([
+            'title' => 'Using FrontMatter with Laravel Blade',
+            'description' => 'How to render FrontMatter & Blade with Spatie Markdown',
+            'extends' => 'layouts.documentation',
+            'section' => 'content',
+            'food' => 'Pizza',
+        ], $frontMatter);
+        $html = $renderedMarkdown->getContent();
+        $this->assertMatchesSnapshot($html);
+    }
+
+    protected function markdownRenderer(): MarkdownRenderer
+    {
+        return app(MarkdownRenderer::class);
+    }
+}

--- a/tests/__snapshots__/MarkdownFrontMatterRendererTest__it_can_parse_many_front_matter_variables__1.txt
+++ b/tests/__snapshots__/MarkdownFrontMatterRendererTest__it_can_parse_many_front_matter_variables__1.txt
@@ -1,0 +1,4 @@
+<h1 id="using-frontmatter-with-laravel-blade">Using FrontMatter with Laravel Blade</h1>
+<p>This is a <a href="https://spatie.be">link to our website</a>.</p>
+<p>The content here would be rendered by markdown first - then you would get the FrontMatter metadata and render it again.
+This time by rendering the template defined in extends, and the HTML content rendered by markdown into the defined section.</p>

--- a/tests/__snapshots__/MarkdownFrontMatterRendererTest__it_can_use_front_matter_extensions__1.txt
+++ b/tests/__snapshots__/MarkdownFrontMatterRendererTest__it_can_use_front_matter_extensions__1.txt
@@ -1,0 +1,4 @@
+<h1 id="my-title">My title</h1>
+<p>This is a <a href="https://spatie.be">link to our website</a></p>
+<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #005CC5">echo</span><span style="color: #24292E"> </span><span style="color: #032F62">&#39;Hello world&#39;</span><span style="color: #24292E">;</span></span>
+<span class="line"></span></code></pre>


### PR DESCRIPTION
hey @freekmurze - this change makes a quick fix for the 2.0 release related to extensions to help ensure things work properly. There were parts of the initial changes I made that were not covered by tests to catch the logic issue.

## Quickfix
Make sure extensions can be given as class names (strings) or instances. So i've made adjustments to ensure extension load properly. 

Specifically these lines would be affected:
https://github.com/spatie/laravel-markdown/blob/991ff79926e3eb6667ed0c2e6793a63825516cf6/src/MarkdownRenderer.php#L149
https://github.com/spatie/laravel-markdown/blob/991ff79926e3eb6667ed0c2e6793a63825516cf6/src/MarkdownRenderer.php#L78

## New feature
This also adds a method that mimics the league `convertToHtml` method for users. Adding this method and covering it with tests was what caused me to encounter the error to begin with. Otherwise I would have opted to split them up.

This addition is important for users that want the `FrontMatterExtension` (or similar). Since these shouldn't return a string directly like existing methods do. So the new method returns a `RenderedContentInterface` object specific to the renderer. For instance, they can use any potential extension specific results. Like:

```php
$result = app(\Spatie\LaravelMarkdown\MarkdownRenderer::class)->renderMarkdown($markdown);

// Grab the front matter:
if ($result instanceof RenderedContentWithFrontMatter) {
    $frontMatter = $result->getFrontMatter();
}
```