### PR TITLE
Allow priority to be set for Block and Inline Renderers

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -67,7 +67,7 @@ return [
      * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
     'block_renderers' => [
-        // ['blockClass' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer()]
+        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],
 
     /*
@@ -77,6 +77,6 @@ return [
      * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
     'inline_renderers' => [
-        // ['blockClass' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer()]
+        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],
 ];

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -98,7 +98,7 @@ return [
      * More info: https://commonmark.thephpleague.com/1.6/customization/block-rendering/
      */
     'block_renderers' => [
-        // ['blockClass' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer()]
+        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],
 
     /*
@@ -108,7 +108,7 @@ return [
  * More info: https://commonmark.thephpleague.com/1.6/customization/inline-rendering/
  */
     'inline_renderers' => [
-        // ['blockClass' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer()]
+        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],
 ];
 ```

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -36,14 +36,14 @@ return [
         /*
          * To highlight code, we'll use Shiki under the hood. Make sure it's installed.
          *
-         * More info: https://github.com/spatie/laravel-markdown#installation
+         * More info: https://spatie.be/docs/laravel-markdown/v1/installation-setup
          */
         'enabled' => true,
 
         /*
          * The name of or path to a Shiki theme
          *
-         * More info: https://github.com/spatie/laravel-markdown#specifying-the-theme-used-for-code-highlighting
+         * More info: https://github.com/shikijs/shiki/blob/master/docs/themes.md
          */
         'theme' => 'github-light',
     ],
@@ -57,7 +57,7 @@ return [
      * These options will be passed to the league/commonmark package which is
      * used under the hood to render markdown.
      *
-     * More info: https://github.com/spatie/laravel-markdown#passing-options-to-commonmark
+     * More info: https://spatie.be/docs/laravel-markdown/v1/using-the-blade-component/passing-options-to-commonmark
      */
     'commonmark_options' => [],
 
@@ -77,36 +77,36 @@ return [
      * You can change this to a class of your own to greatly
      * customize the rendering process
      *
-     * More info: https://github.com/spatie/laravel-markdown#customizing-the-rendering-process
+     * More info: https://spatie.be/docs/laravel-markdown/v1/advanced-usage/customizing-the-rendering-process
      */
     'renderer_class' => Spatie\LaravelMarkdown\MarkdownRenderer::class,
 
     /*
-     * These extensions should be added to the markdown environment. An valid
+     * These extensions should be added to the markdown environment. A valid
      * extension implements League\CommonMark\Extension\ExtensionInterface
      *
-     * More info: https://commonmark.thephpleague.com/1.6/extensions/overview/
+     * More info: https://commonmark.thephpleague.com/2.0/extensions/overview/
      */
     'extensions' => [
         //
     ],
 
     /*
-     * These block renderers should be added to the markdown environment. An valid
-     * renderer implements League\CommonMark\Block\Renderer\BlockRendererInterface;
+     * These block renderers should be added to the markdown environment. A valid
+     * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
      *
-     * More info: https://commonmark.thephpleague.com/1.6/customization/block-rendering/
+     * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
     'block_renderers' => [
         // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],
 
     /*
-     * These inline renderers should be added to the markdown environment. An valid
-     * renderer implements League\CommonMark\Block\Renderer\InlineRendererInterface;
- *
- * More info: https://commonmark.thephpleague.com/1.6/customization/inline-rendering/
- */
+     * These inline renderers should be added to the markdown environment. A valid
+     * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
+     */
     'inline_renderers' => [
         // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -147,11 +147,11 @@ class MarkdownRenderer
         }
 
         foreach ($this->blockRenderers as $blockRenderer) {
-            $environment->addRenderer($blockRenderer['class'], $blockRenderer['renderer']);
+            $environment->addRenderer($blockRenderer['class'], $blockRenderer['renderer'], $blockRenderer['priority'] ?? 0);
         }
 
         foreach ($this->inlineRenderers as $inlineRenderer) {
-            $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer']);
+            $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer'], $blockRenderer['priority'] ?? 0);
         }
     }
 


### PR DESCRIPTION
Hi,

I noticed when trying to add a custom renderer that there was no way to pass a priority option through (meaning that if a renderer for the element type had already been registered and returned a non-`null` result, the renderer added to the config wouldn't be used).

This PR allows a priority key to be set for block / inline renderers, but falls back to 0 if not found. (0 is the default priority, so without adding the new key nothing should change),

I have also updated the comments in the config file to have the correct array key (`class` instead of `blockClass`) and bought the installation setup documentation page to be inline with the config file (as many of the comments were already out of date before I made my own changes to the config file).

As an complete aside, locally I went to run the tests just to be sure nothing I changed caused any issues, but I was getting a number of failures even when I reverted my changes and I'm really not sure why.
