### PR TITLE
Add tests to identify and fix bug with renderers priority

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -54,7 +54,7 @@ return [
      * These extensions should be added to the markdown environment. A valid
      * extension implements League\CommonMark\Extension\ExtensionInterface
      *
-     * More info: https://commonmark.thephpleague.com/2.0/extensions/overview/
+     * More info: https://commonmark.thephpleague.com/2.1/extensions/overview/
      */
     'extensions' => [
         //
@@ -64,7 +64,7 @@ return [
      * These block renderers should be added to the markdown environment. A valid
      * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
      *
-     * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
+     * More info: https://commonmark.thephpleague.com/2.1/customization/rendering/
      */
     'block_renderers' => [
         // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
@@ -74,7 +74,7 @@ return [
      * These inline renderers should be added to the markdown environment. A valid
      * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
      *
-     * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
+     * More info: https://commonmark.thephpleague.com/2.1/customization/rendering/
      */
     'inline_renderers' => [
         // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -151,7 +151,7 @@ class MarkdownRenderer
         }
 
         foreach ($this->inlineRenderers as $inlineRenderer) {
-            $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer'], $blockRenderer['priority'] ?? 0);
+            $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer'], $inlineRenderer['priority'] ?? 0);
         }
     }
 

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -83,16 +83,16 @@ class MarkdownRenderer
         return $this;
     }
 
-    public function addBlockRenderer(string $blockClass, NodeRendererInterface $blockRenderer): self
+    public function addBlockRenderer(string $blockClass, NodeRendererInterface $blockRenderer, ?int $priority = 0): self
     {
-        $this->blockRenderers[] = ['class' => $blockClass, 'renderer' => $blockRenderer];
+        $this->blockRenderers[] = ['class' => $blockClass, 'renderer' => $blockRenderer, 'priority' => $priority];
 
         return $this;
     }
 
-    public function addInlineRenderer(string $inlineClass, NodeRendererInterface $inlineRenderer): self
+    public function addInlineRenderer(string $inlineClass, NodeRendererInterface $inlineRenderer, ?int $priority = 0): self
     {
-        $this->inlineRenderers[] = ['class' => $inlineClass, 'renderer' => $inlineRenderer];
+        $this->inlineRenderers[] = ['class' => $inlineClass, 'renderer' => $inlineRenderer, 'priority' => $priority];
 
         return $this;
     }

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -61,14 +61,14 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_register_inline_renderers()
     {
         config()->set('markdown.inline_renderers', [
-            ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 25],
+            ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 42],
         ]);
 
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
         $refelctionClass = new \ReflectionClass($renderers);
         $reflectionProperty = $refelctionClass->getProperty('list');
-        $this->assertEquals(25, array_keys($reflectionProperty->getValue($renderers))[0]);
-        $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[25][0]);
+        $this->assertEquals(42, array_keys($reflectionProperty->getValue($renderers))[0]);
+        $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[42][0]);
     }
 
     protected function markdownRenderer(): MarkdownRenderer

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\LaravelMarkdown\Tests;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\MarkdownConverter;
+use ReflectionClass;
 use Spatie\LaravelMarkdown\MarkdownRenderer;
 use Spatie\LaravelMarkdown\Tests\Stubs\InlineTextDividerRenderer;
 use Spatie\LaravelMarkdown\Tests\Stubs\TextDividerRenderer;
@@ -17,7 +18,7 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_modify_highlight_code_option()
     {
         $markdownRenderer = $this->markdownRenderer();
-        $reflectedClass = new \ReflectionClass($markdownRenderer);
+        $reflectedClass = new ReflectionClass($markdownRenderer);
         $reflectedProperty = $reflectedClass->getProperty('highlightCode');
         $reflectedProperty->setAccessible(true);
         $previousValue = $reflectedProperty->getValue($markdownRenderer);
@@ -31,7 +32,7 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_modify_render_anchors_option()
     {
         $markdownRenderer = $this->markdownRenderer();
-        $reflectedClass = new \ReflectionClass($markdownRenderer);
+        $reflectedClass = new ReflectionClass($markdownRenderer);
         $reflectedProperty = $reflectedClass->getProperty('renderAnchors');
         $reflectedProperty->setAccessible(true);
         $previousValue = $reflectedProperty->getValue($markdownRenderer);
@@ -49,7 +50,7 @@ class MarkdownRendererSettingsTest extends TestCase
         ]);
 
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        $refelctionClass = new \ReflectionClass($renderers);
+        $refelctionClass = new ReflectionClass($renderers);
         $reflectionProperty = $refelctionClass->getProperty('list');
         $reflectionProperty->setAccessible(true);
         $this->assertEquals(25, array_keys($reflectionProperty->getValue($renderers))[0]);
@@ -64,7 +65,7 @@ class MarkdownRendererSettingsTest extends TestCase
         ]);
 
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        $refelctionClass = new \ReflectionClass($renderers);
+        $refelctionClass = new ReflectionClass($renderers);
         $reflectionProperty = $refelctionClass->getProperty('list');
         $reflectionProperty->setAccessible(true);
         $this->assertEquals(42, array_keys($reflectionProperty->getValue($renderers))[0]);
@@ -80,7 +81,7 @@ class MarkdownRendererSettingsTest extends TestCase
 
         $markdownConverter = $this->markdownConverter($markdownRenderer);
         $renderersList = $markdownConverter->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        $refelctionClass = new \ReflectionClass($renderersList);
+        $refelctionClass = new ReflectionClass($renderersList);
         $reflectionProperty = $refelctionClass->getProperty('list');
         $reflectionProperty->setAccessible(true);
         $orderedList = $reflectionProperty->getValue($renderersList);
@@ -100,7 +101,7 @@ class MarkdownRendererSettingsTest extends TestCase
         if ($markdownRenderer === null) {
             $markdownRenderer = app(MarkdownRenderer::class);
         }
-        $reflectionClass = new \ReflectionClass(MarkdownRenderer::class);
+        $reflectionClass = new ReflectionClass(MarkdownRenderer::class);
         $reflectionMethod = $reflectionClass->getMethod('getMarkdownConverter');
         $reflectionMethod->setAccessible(true);
 

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -53,6 +53,7 @@ class MarkdownRendererSettingsTest extends TestCase
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
         $refelctionClass = new \ReflectionClass($renderers);
         $reflectionProperty = $refelctionClass->getProperty('list');
+        $reflectionProperty->setAccessible(true);
         $this->assertEquals(25, array_keys($reflectionProperty->getValue($renderers))[0]);
         $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[25][0]);
     }
@@ -67,6 +68,7 @@ class MarkdownRendererSettingsTest extends TestCase
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
         $refelctionClass = new \ReflectionClass($renderers);
         $reflectionProperty = $refelctionClass->getProperty('list');
+        $reflectionProperty->setAccessible(true);
         $this->assertEquals(42, array_keys($reflectionProperty->getValue($renderers))[0]);
         $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[42][0]);
     }

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -81,6 +81,7 @@ class MarkdownRendererSettingsTest extends TestCase
         $reflectionClass = new \ReflectionClass(MarkdownRenderer::class);
         $reflectionMethod = $reflectionClass->getMethod('getMarkdownConverter');
         $reflectionMethod->setAccessible(true);
+
         return $reflectionMethod->invoke(app(MarkdownRenderer::class));
     }
 }

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -18,28 +18,28 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_modify_highlight_code_option()
     {
         $markdownRenderer = $this->markdownRenderer();
-        $reflectedClass = new ReflectionClass($markdownRenderer);
-        $reflectedProperty = $reflectedClass->getProperty('highlightCode');
-        $reflectedProperty->setAccessible(true);
-        $previousValue = $reflectedProperty->getValue($markdownRenderer);
-        $this->assertTrue($previousValue);
+        // get and verify initial value
+        $initialValue = $this->getProtectedPropertyValue($markdownRenderer, 'highlightCode');
+        $this->assertTrue($initialValue);
+        // Call a method that modifies the value...
         $markdownRenderer->highlightCode(false);
-        $this->assertNotEquals($previousValue, $reflectedProperty->getValue($markdownRenderer));
-        $this->assertFalse(($previousValue = $reflectedProperty->getValue($markdownRenderer)));
+        // Verify the value changed from previous value and is now false
+        $this->assertNotEquals($initialValue, $this->getProtectedPropertyValue($markdownRenderer, 'highlightCode'));
+        $this->assertFalse($this->getProtectedPropertyValue($markdownRenderer, 'highlightCode'));
     }
 
     /** @test */
     public function it_can_modify_render_anchors_option()
     {
         $markdownRenderer = $this->markdownRenderer();
-        $reflectedClass = new ReflectionClass($markdownRenderer);
-        $reflectedProperty = $reflectedClass->getProperty('renderAnchors');
-        $reflectedProperty->setAccessible(true);
-        $previousValue = $reflectedProperty->getValue($markdownRenderer);
-        $this->assertTrue($previousValue);
+        // get and verify initial value
+        $initialValue = $this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors');
+        $this->assertTrue($initialValue);
+        // Call a method that modifies the value...
         $markdownRenderer->renderAnchors(false);
-        $this->assertNotEquals($previousValue, $reflectedProperty->getValue($markdownRenderer));
-        $this->assertFalse(($previousValue = $reflectedProperty->getValue($markdownRenderer)));
+        // Verify the value changed from previous value and is now false
+        $this->assertNotEquals($initialValue, $this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors'));
+        $this->assertFalse($this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors'));
     }
 
     /** @test */
@@ -106,5 +106,13 @@ class MarkdownRendererSettingsTest extends TestCase
         $reflectionMethod->setAccessible(true);
 
         return $reflectionMethod->invoke($markdownRenderer);
+    }
+
+    protected function getProtectedPropertyValue(object $object, string $propertyName)
+    {
+        $reflectedClass = new ReflectionClass($object);
+        $reflectedProperty = $reflectedClass->getProperty($propertyName);
+        $reflectedProperty->setAccessible(true);
+        return $reflectedProperty->getValue($object);
     }
 }

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -18,12 +18,11 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_modify_highlight_code_option()
     {
         $markdownRenderer = $this->markdownRenderer();
-        // get and verify initial value
         $initialValue = $this->getProtectedPropertyValue($markdownRenderer, 'highlightCode');
         $this->assertTrue($initialValue);
-        // Call a method that modifies the value...
+        
         $markdownRenderer->highlightCode(false);
-        // Verify the value changed from previous value and is now false
+
         $this->assertNotEquals($initialValue, $this->getProtectedPropertyValue($markdownRenderer, 'highlightCode'));
         $this->assertFalse($this->getProtectedPropertyValue($markdownRenderer, 'highlightCode'));
     }
@@ -32,12 +31,11 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_modify_render_anchors_option()
     {
         $markdownRenderer = $this->markdownRenderer();
-        // get and verify initial value
         $initialValue = $this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors');
         $this->assertTrue($initialValue);
-        // Call a method that modifies the value...
+        
         $markdownRenderer->renderAnchors(false);
-        // Verify the value changed from previous value and is now false
+        
         $this->assertNotEquals($initialValue, $this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors'));
         $this->assertFalse($this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors'));
     }
@@ -49,11 +47,9 @@ class MarkdownRendererSettingsTest extends TestCase
             ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 25],
         ]);
 
-        // Using the configured Environment get all the Renderers for the ThematicBreak class
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        // Get the raw list from the priority list...this ensures we preserve the ordered IDs
         $priorityArray = $this->getProtectedPropertyValue($renderers, 'list');
-        // Verify the items registered via 'markdown.block_renderers' were registered with the proper priority
+
         $this->assertEquals(25, array_keys($priorityArray)[0]);
         $this->assertArrayHasKey(25, $priorityArray);
         $this->assertArrayHasKey(0, $priorityArray[25]);
@@ -67,11 +63,9 @@ class MarkdownRendererSettingsTest extends TestCase
             ['class' => ThematicBreak::class, 'renderer' => new InlineTextDividerRenderer(), 'priority' => 42],
         ]);
 
-        // Using the configured Environment get all the Renderers for the ThematicBreak class
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        // Get the raw list from the priority list...this ensures we preserve the ordered IDs
         $priorityArray = $this->getProtectedPropertyValue($renderers, 'list');
-        // Verify the items registered via 'markdown.inline_renderers' were registered with the proper priority
+
         $this->assertEquals(42, array_keys($priorityArray)[0]);
         $this->assertArrayHasKey(42, $priorityArray);
         $this->assertArrayHasKey(0, $priorityArray[42]);
@@ -81,16 +75,14 @@ class MarkdownRendererSettingsTest extends TestCase
     /** @test */
     public function it_can_dynamically_register_renderers()
     {
-        // Prepare a version of markdown renderer to add block/inline renderer via method..
         $markdownRenderer = $this->markdownRenderer();
         $markdownRenderer = $markdownRenderer->addBlockRenderer(ThematicBreak::class, new TextDividerRenderer(), 42);
         $markdownRenderer = $markdownRenderer->addInlineRenderer(ThematicBreak::class, new InlineTextDividerRenderer(), 25);
-        // Get the normally protected markdown converter and renderers list
+
         $markdownConverter = $this->markdownConverter($markdownRenderer);
         $renderersList = $markdownConverter->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        // Get the raw list from the priority list...this ensures we preserve the ordered IDs
         $priorityArray = $this->getProtectedPropertyValue($renderersList, 'list');
-        // Verify the items registered via 'markdown.inline_renderers' were registered with the proper priority
+
         $this->assertEquals(42, array_keys($priorityArray)[0]);
         $this->assertArrayHasKey(42, $priorityArray);
         $this->assertInstanceOf(TextDividerRenderer::class, $priorityArray[42][0]);
@@ -109,6 +101,7 @@ class MarkdownRendererSettingsTest extends TestCase
         if ($markdownRenderer === null) {
             $markdownRenderer = app(MarkdownRenderer::class);
         }
+        
         $reflectionClass = new ReflectionClass(MarkdownRenderer::class);
         $reflectionMethod = $reflectionClass->getMethod('getMarkdownConverter');
         $reflectionMethod->setAccessible(true);
@@ -116,11 +109,12 @@ class MarkdownRendererSettingsTest extends TestCase
         return $reflectionMethod->invoke($markdownRenderer);
     }
 
-    protected function getProtectedPropertyValue(object $object, string $propertyName)
+    protected function getProtectedPropertyValue(object $object, string $propertyName): mixed
     {
         $reflectedClass = new ReflectionClass($object);
         $reflectedProperty = $reflectedClass->getProperty($propertyName);
         $reflectedProperty->setAccessible(true);
+        
         return $reflectedProperty->getValue($object);
     }
 }

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -62,7 +62,7 @@ class MarkdownRendererSettingsTest extends TestCase
     public function it_can_register_inline_renderers()
     {
         config()->set('markdown.inline_renderers', [
-            ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 42],
+            ['class' => ThematicBreak::class, 'renderer' => new InlineTextDividerRenderer(), 'priority' => 42],
         ]);
 
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
@@ -70,7 +70,26 @@ class MarkdownRendererSettingsTest extends TestCase
         $reflectionProperty = $refelctionClass->getProperty('list');
         $reflectionProperty->setAccessible(true);
         $this->assertEquals(42, array_keys($reflectionProperty->getValue($renderers))[0]);
-        $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[42][0]);
+        $this->assertInstanceOf(InlineTextDividerRenderer::class, $reflectionProperty->getValue($renderers)[42][0]);
+    }
+
+    /** @test */
+    public function it_can_dynamically_register_renderers()
+    {
+        $markdownRenderer = $this->markdownRenderer();
+        $markdownRenderer = $markdownRenderer->addBlockRenderer(ThematicBreak::class, new TextDividerRenderer(), 42);
+        $markdownRenderer = $markdownRenderer->addInlineRenderer(ThematicBreak::class, new InlineTextDividerRenderer(), 25);
+
+        $markdownConverter = $this->markdownConverter($markdownRenderer);
+        $renderersList = $markdownConverter->getEnvironment()->getRenderersForClass(ThematicBreak::class);
+        $refelctionClass = new \ReflectionClass($renderersList);
+        $reflectionProperty = $refelctionClass->getProperty('list');
+        $reflectionProperty->setAccessible(true);
+        $orderedList = $reflectionProperty->getValue($renderersList);
+        $this->assertEquals(42, array_keys($orderedList)[0]);
+        $this->assertEquals(25, array_keys($orderedList)[1]);
+        $this->assertInstanceOf(TextDividerRenderer::class, $orderedList[42][0]);
+        $this->assertInstanceOf(InlineTextDividerRenderer::class, $orderedList[25][0]);
     }
 
     protected function markdownRenderer(): MarkdownRenderer
@@ -78,17 +97,28 @@ class MarkdownRendererSettingsTest extends TestCase
         return app(MarkdownRenderer::class);
     }
 
-    protected function markdownConverter(): MarkdownConverter
+    protected function markdownConverter(?MarkdownRenderer $markdownRenderer = null): MarkdownConverter
     {
+        if ($markdownRenderer === null) {
+            $markdownRenderer = app(MarkdownRenderer::class);
+        }
         $reflectionClass = new \ReflectionClass(MarkdownRenderer::class);
         $reflectionMethod = $reflectionClass->getMethod('getMarkdownConverter');
         $reflectionMethod->setAccessible(true);
 
-        return $reflectionMethod->invoke(app(MarkdownRenderer::class));
+        return $reflectionMethod->invoke($markdownRenderer);
     }
 }
 
 class TextDividerRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        return new HtmlElement('pre', ['class' => 'divider'], '==============================');
+    }
+}
+
+class InlineTextDividerRenderer implements NodeRendererInterface
 {
     public function render(Node $node, ChildNodeRendererInterface $childRenderer)
     {

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spatie\LaravelMarkdown\Tests;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
+use League\CommonMark\MarkdownConverter;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+use Spatie\LaravelMarkdown\MarkdownRenderer;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class MarkdownRendererSettingsTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    /** @test */
+    public function it_can_modify_highlight_code_option()
+    {
+        $markdownRenderer = $this->markdownRenderer();
+        $reflectedClass = new \ReflectionClass($markdownRenderer);
+        $reflectedProperty = $reflectedClass->getProperty('highlightCode');
+        $reflectedProperty->setAccessible(true);
+        $previousValue = $reflectedProperty->getValue($markdownRenderer);
+        $this->assertTrue($previousValue);
+        $markdownRenderer->highlightCode(false);
+        $this->assertNotEquals($previousValue, $reflectedProperty->getValue($markdownRenderer));
+        $this->assertFalse(($previousValue = $reflectedProperty->getValue($markdownRenderer)));
+    }
+
+    /** @test */
+    public function it_can_modify_render_anchors_option()
+    {
+        $markdownRenderer = $this->markdownRenderer();
+        $reflectedClass = new \ReflectionClass($markdownRenderer);
+        $reflectedProperty = $reflectedClass->getProperty('renderAnchors');
+        $reflectedProperty->setAccessible(true);
+        $previousValue = $reflectedProperty->getValue($markdownRenderer);
+        $this->assertTrue($previousValue);
+        $markdownRenderer->renderAnchors(false);
+        $this->assertNotEquals($previousValue, $reflectedProperty->getValue($markdownRenderer));
+        $this->assertFalse(($previousValue = $reflectedProperty->getValue($markdownRenderer)));
+    }
+
+    /** @test */
+    public function it_can_register_block_renderers()
+    {
+        config()->set('markdown.block_renderers', [
+            ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 25],
+        ]);
+
+        $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
+        $refelctionClass = new \ReflectionClass($renderers);
+        $reflectionProperty = $refelctionClass->getProperty('list');
+        $this->assertEquals(25, array_keys($reflectionProperty->getValue($renderers))[0]);
+        $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[25][0]);
+    }
+
+    /** @test */
+    public function it_can_register_inline_renderers()
+    {
+        config()->set('markdown.inline_renderers', [
+            ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 25],
+        ]);
+
+        $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
+        $refelctionClass = new \ReflectionClass($renderers);
+        $reflectionProperty = $refelctionClass->getProperty('list');
+        $this->assertEquals(25, array_keys($reflectionProperty->getValue($renderers))[0]);
+        $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[25][0]);
+    }
+
+    protected function markdownRenderer(): MarkdownRenderer
+    {
+        return app(MarkdownRenderer::class);
+    }
+
+    protected function markdownConverter(): MarkdownConverter
+    {
+        $reflectionClass = new \ReflectionClass(MarkdownRenderer::class);
+        $reflectionMethod = $reflectionClass->getMethod('getMarkdownConverter');
+        $reflectionMethod->setAccessible(true);
+        return $reflectionMethod->invoke(app(MarkdownRenderer::class));
+    }
+}
+
+class TextDividerRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        return new HtmlElement('pre', ['class' => 'divider'], '==============================');
+    }
+}

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -49,12 +49,15 @@ class MarkdownRendererSettingsTest extends TestCase
             ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 25],
         ]);
 
+        // Using the configured Environment get all the Renderers for the ThematicBreak class
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        $refelctionClass = new ReflectionClass($renderers);
-        $reflectionProperty = $refelctionClass->getProperty('list');
-        $reflectionProperty->setAccessible(true);
-        $this->assertEquals(25, array_keys($reflectionProperty->getValue($renderers))[0]);
-        $this->assertInstanceOf(TextDividerRenderer::class, $reflectionProperty->getValue($renderers)[25][0]);
+        // Get the raw list from the priority list...this ensures we preserve the ordered IDs
+        $priorityArray = $this->getProtectedPropertyValue($renderers, 'list');
+        // Verify the items registered via 'markdown.block_renderers' were registered with the proper priority
+        $this->assertEquals(25, array_keys($priorityArray)[0]);
+        $this->assertArrayHasKey(25, $priorityArray);
+        $this->assertArrayHasKey(0, $priorityArray[25]);
+        $this->assertInstanceOf(TextDividerRenderer::class, $priorityArray[25][0]);
     }
 
     /** @test */
@@ -64,31 +67,36 @@ class MarkdownRendererSettingsTest extends TestCase
             ['class' => ThematicBreak::class, 'renderer' => new InlineTextDividerRenderer(), 'priority' => 42],
         ]);
 
+        // Using the configured Environment get all the Renderers for the ThematicBreak class
         $renderers = $this->markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        $refelctionClass = new ReflectionClass($renderers);
-        $reflectionProperty = $refelctionClass->getProperty('list');
-        $reflectionProperty->setAccessible(true);
-        $this->assertEquals(42, array_keys($reflectionProperty->getValue($renderers))[0]);
-        $this->assertInstanceOf(InlineTextDividerRenderer::class, $reflectionProperty->getValue($renderers)[42][0]);
+        // Get the raw list from the priority list...this ensures we preserve the ordered IDs
+        $priorityArray = $this->getProtectedPropertyValue($renderers, 'list');
+        // Verify the items registered via 'markdown.inline_renderers' were registered with the proper priority
+        $this->assertEquals(42, array_keys($priorityArray)[0]);
+        $this->assertArrayHasKey(42, $priorityArray);
+        $this->assertArrayHasKey(0, $priorityArray[42]);
+        $this->assertInstanceOf(InlineTextDividerRenderer::class, $priorityArray[42][0]);
     }
 
     /** @test */
     public function it_can_dynamically_register_renderers()
     {
+        // Prepare a version of markdown renderer to add block/inline renderer via method..
         $markdownRenderer = $this->markdownRenderer();
         $markdownRenderer = $markdownRenderer->addBlockRenderer(ThematicBreak::class, new TextDividerRenderer(), 42);
         $markdownRenderer = $markdownRenderer->addInlineRenderer(ThematicBreak::class, new InlineTextDividerRenderer(), 25);
-
+        // Get the normally protected markdown converter and renderers list
         $markdownConverter = $this->markdownConverter($markdownRenderer);
         $renderersList = $markdownConverter->getEnvironment()->getRenderersForClass(ThematicBreak::class);
-        $refelctionClass = new ReflectionClass($renderersList);
-        $reflectionProperty = $refelctionClass->getProperty('list');
-        $reflectionProperty->setAccessible(true);
-        $orderedList = $reflectionProperty->getValue($renderersList);
-        $this->assertEquals(42, array_keys($orderedList)[0]);
-        $this->assertEquals(25, array_keys($orderedList)[1]);
-        $this->assertInstanceOf(TextDividerRenderer::class, $orderedList[42][0]);
-        $this->assertInstanceOf(InlineTextDividerRenderer::class, $orderedList[25][0]);
+        // Get the raw list from the priority list...this ensures we preserve the ordered IDs
+        $priorityArray = $this->getProtectedPropertyValue($renderersList, 'list');
+        // Verify the items registered via 'markdown.inline_renderers' were registered with the proper priority
+        $this->assertEquals(42, array_keys($priorityArray)[0]);
+        $this->assertArrayHasKey(42, $priorityArray);
+        $this->assertInstanceOf(TextDividerRenderer::class, $priorityArray[42][0]);
+        $this->assertEquals(25, array_keys($priorityArray)[1]);
+        $this->assertArrayHasKey(25, $priorityArray);
+        $this->assertInstanceOf(InlineTextDividerRenderer::class, $priorityArray[25][0]);
     }
 
     protected function markdownRenderer(): MarkdownRenderer

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -4,11 +4,9 @@ namespace Spatie\LaravelMarkdown\Tests;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\MarkdownConverter;
-use League\CommonMark\Node\Node;
-use League\CommonMark\Renderer\ChildNodeRendererInterface;
-use League\CommonMark\Renderer\NodeRendererInterface;
-use League\CommonMark\Util\HtmlElement;
 use Spatie\LaravelMarkdown\MarkdownRenderer;
+use Spatie\LaravelMarkdown\Tests\Stubs\InlineTextDividerRenderer;
+use Spatie\LaravelMarkdown\Tests\Stubs\TextDividerRenderer;
 use Spatie\Snapshots\MatchesSnapshots;
 
 class MarkdownRendererSettingsTest extends TestCase
@@ -107,21 +105,5 @@ class MarkdownRendererSettingsTest extends TestCase
         $reflectionMethod->setAccessible(true);
 
         return $reflectionMethod->invoke($markdownRenderer);
-    }
-}
-
-class TextDividerRenderer implements NodeRendererInterface
-{
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
-    {
-        return new HtmlElement('pre', ['class' => 'divider'], '==============================');
-    }
-}
-
-class InlineTextDividerRenderer implements NodeRendererInterface
-{
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
-    {
-        return new HtmlElement('pre', ['class' => 'divider'], '==============================');
     }
 }

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -20,7 +20,7 @@ class MarkdownRendererSettingsTest extends TestCase
         $markdownRenderer = $this->markdownRenderer();
         $initialValue = $this->getProtectedPropertyValue($markdownRenderer, 'highlightCode');
         $this->assertTrue($initialValue);
-        
+
         $markdownRenderer->highlightCode(false);
 
         $this->assertNotEquals($initialValue, $this->getProtectedPropertyValue($markdownRenderer, 'highlightCode'));
@@ -33,9 +33,9 @@ class MarkdownRendererSettingsTest extends TestCase
         $markdownRenderer = $this->markdownRenderer();
         $initialValue = $this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors');
         $this->assertTrue($initialValue);
-        
+
         $markdownRenderer->renderAnchors(false);
-        
+
         $this->assertNotEquals($initialValue, $this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors'));
         $this->assertFalse($this->getProtectedPropertyValue($markdownRenderer, 'renderAnchors'));
     }
@@ -101,7 +101,7 @@ class MarkdownRendererSettingsTest extends TestCase
         if ($markdownRenderer === null) {
             $markdownRenderer = app(MarkdownRenderer::class);
         }
-        
+
         $reflectionClass = new ReflectionClass(MarkdownRenderer::class);
         $reflectionMethod = $reflectionClass->getMethod('getMarkdownConverter');
         $reflectionMethod->setAccessible(true);
@@ -114,7 +114,7 @@ class MarkdownRendererSettingsTest extends TestCase
         $reflectedClass = new ReflectionClass($object);
         $reflectedProperty = $reflectedClass->getProperty($propertyName);
         $reflectedProperty->setAccessible(true);
-        
+
         return $reflectedProperty->getValue($object);
     }
 }

--- a/tests/Stubs/InlineTextDividerRenderer.php
+++ b/tests/Stubs/InlineTextDividerRenderer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\LaravelMarkdown\Tests\Stubs;
+
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+
+class InlineTextDividerRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        return new HtmlElement('pre', ['class' => 'divider'], '==============================');
+    }
+}

--- a/tests/Stubs/TextDividerRenderer.php
+++ b/tests/Stubs/TextDividerRenderer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\LaravelMarkdown\Tests\Stubs;
+
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+
+class TextDividerRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        return new HtmlElement('pre', ['class' => 'divider'], '==============================');
+    }
+}


### PR DESCRIPTION
Per title, this PR creates a test that identifies a bug and fixes said bug.

Up until commit https://github.com/spatie/laravel-markdown/pull/26/commits/3154c0dba645522a61f51176d654013e6888d9d5 the PR has intentioally failing builds. However at commit https://github.com/spatie/laravel-markdown/pull/26/commits/2da77b7253cc05f9a486d592d941450d7a0d0487 the underlying bug was fixed and the subsequent PR adds a method parameter to bring the `addBlockRenderer` and `addInlineRenderer` methods in parity with the new funtionality.