### PR TITLE
Fix broken link in code highlighting documentation

### DIFF
--- a/docs/rendering-markdown/configuring-code-highlighting.md
+++ b/docs/rendering-markdown/configuring-code-highlighting.md
@@ -5,7 +5,7 @@ weight: 2
 
 By default, [Shiki PHP](https://github.com/spatie/shiki-php)  is used to highlight  100+ languages, including PHP, JS, Blade, [and many more](https://githubcom/shikijs/shiki/blob/master/docs/languages.md).
 
-In the `code_highlighting.theme` value op the `markdown` config file you can specify the default theme to be used. This value can be [one of the themes]((https://github.com/shikijs/shiki/blob/master/docs/themes.md)) that Shiki supports out of the box.
+In the `code_highlighting.theme` value op the `markdown` config file you can specify the default theme to be used. This value can be [one of the themes](https://github.com/shikijs/shiki/blob/master/docs/themes.md) that Shiki supports out of the box.
 
 ## Configuring a theme
 


### PR DESCRIPTION
Noticed a small issue with the link markdown being incorrect, this should fix it.