### PR TITLE
Side note for using blade's unescaped statememt

### DIFF
--- a/docs/using-the-blade-component/general-usage.md
+++ b/docs/using-the-blade-component/general-usage.md
@@ -31,3 +31,9 @@ echo 'Hello world';
 <span class="line"></span></code></pre>
 </div>
 ```
+
+*Note:* If you're outputting the Markdown through blade, rather than direct input, you will need to use the unescaped blade statement to prevent Laravel's XSS protection stripping the tags:
+
+```blade
+{!! $article->content !!}
+```


### PR DESCRIPTION
This caught me off guard (Shouldn't have, but I'm tired!). I thought it would be worth a little footnote. If you use default blade statement:

```blade
{{ $article->markdown }}
```

The markdown is passed through PHP's `htmlspecialchars` function and all the HTML specific tags `< > ' ` etc are replaced with their ASCII equivalent. To stop this (And for your lovely package to work) a user would need to use the unescaped, effectively raw blade statement:

```blade
{!! $article->markdown !!}
```