### PR TITLE
Adding inline parsers

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -79,4 +79,14 @@ return [
     'inline_renderers' => [
         // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
     ],
+
+    /*
+     * These inline parsers should be added to the markdown environment. A valid
+     * parser implements League\CommonMark\Renderer\InlineParserInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.3/customization/inline-parsing/
+     */
+    'inline_parsers' => [
+        // ['parser' => new MyCustomInlineParser(), 'priority' => 0]
+    ],
 ];

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -24,6 +24,7 @@ class MarkdownRenderer
         protected array $extensions = [],
         protected array $blockRenderers = [],
         protected array $inlineRenderers = [],
+        protected array $inlineParsers = [],
     ) {
     }
 
@@ -152,6 +153,10 @@ class MarkdownRenderer
 
         foreach ($this->inlineRenderers as $inlineRenderer) {
             $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer'], $inlineRenderer['priority'] ?? 0);
+        }
+
+        foreach ($this->inlineParsers as $inlineParser) {
+            $environment->addInlineParser($inlineParser['parser'], $inlineParser['priority'] ?? 0);
         }
     }
 

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -32,6 +32,7 @@ class MarkdownServiceProvider extends PackageServiceProvider
                 extensions: $config['extensions'],
                 blockRenderers: $config['block_renderers'],
                 inlineRenderers: $config['inline_renderers'],
+                inlineParsers: $config['inline_parsers'],
             );
         });
     }

--- a/tests/MarkdownInlineParserTest.php
+++ b/tests/MarkdownInlineParserTest.php
@@ -2,7 +2,35 @@
 
 namespace Spatie\LaravelMarkdown\Tests;
 
+
+use Spatie\LaravelMarkdown\MarkdownRenderer;
+use Spatie\LaravelMarkdown\Tests\Stubs\CustomInlineParser;
+
 class MarkdownInlineParserTest extends TestCase
 {
+
+    /** @test */
+    public function it_can_use_custom_inline_parser()
+    {
+        config()->set('markdown.inline_parsers', [
+            ['parser' => new CustomInlineParser(), 'priority' => 0]
+        ]);
+
+        $markdown = <<<MD
+            I am a text with a very randomly placed @ symbol in the middle.
+           MD;
+
+        $html = $this
+            ->markdownRenderer()
+            ->disableAnchors()
+            ->toHtml($markdown);
+
+        $this->assertEquals('<p>I am a text with a very randomly placed THIS-REPLACED-THE-SYMBOL symbol in the middle.</p>' . PHP_EOL, $html);
+    }
+
+    protected function markdownRenderer(): MarkdownRenderer
+    {
+        return app(MarkdownRenderer::class);
+    }
 
 }

--- a/tests/MarkdownInlineParserTest.php
+++ b/tests/MarkdownInlineParserTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelMarkdown\Tests;
+
+class MarkdownInlineParserTest extends TestCase
+{
+
+}

--- a/tests/Stubs/CustomInlineParser.php
+++ b/tests/Stubs/CustomInlineParser.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\LaravelMarkdown\Tests\Stubs;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\HtmlInline;
+use League\CommonMark\Parser\Inline\InlineParserMatch;
+use League\CommonMark\Parser\InlineParserContext;
+
+class CustomInlineParser implements \League\CommonMark\Parser\Inline\InlineParserInterface
+{
+
+    const REPLACE = "THIS-REPLACED-THE-SYMBOL";
+
+    public function getMatchDefinition(): InlineParserMatch
+    {
+        return InlineParserMatch::string('@');
+    }
+
+    public function parse(InlineParserContext $inlineContext): bool
+    {
+        $cursor = $inlineContext->getCursor();
+        $cursor->advanceBy($inlineContext->getFullMatchLength());
+        $inlineContext->getContainer()->appendChild(new HtmlInline(self::REPLACE));
+        return true;
+    }
+}


### PR DESCRIPTION
The inline parsers are very useful. 

For example if one wanted to add a hashtag system, or a "mention" system using match for @somename like here in github, they could make an inline parser as in the example on commonmark: https://commonmark.thephpleague.com/2.3/customization/inline-parsing/#inline-parser-examples

This pr simply adds the option to the config