### PR TITLE
MarkdownBladeComponent missing inline parsers

### DIFF
--- a/src/MarkdownBladeComponent.php
+++ b/src/MarkdownBladeComponent.php
@@ -28,6 +28,7 @@ class MarkdownBladeComponent extends Component
             extensions: $config['extensions'],
             blockRenderers: $config['block_renderers'],
             inlineRenderers: $config['inline_renderers'],
+            inlineParsers: $config['inline_parsers'],
         );
 
         return $markdownRenderer->toHtml($markdown);


### PR DESCRIPTION
Configured inline parsers should also be in the configured markdown renderer