### PR TITLE
Support class names for config serialization

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -67,7 +67,7 @@ return [
      * More info: https://commonmark.thephpleague.com/2.1/customization/rendering/
      */
     'block_renderers' => [
-        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
+        // ['class' => FencedCode::class, 'renderer' => MyCustomCodeRenderer::class, 'priority' => 0]
     ],
 
     /*
@@ -77,7 +77,7 @@ return [
      * More info: https://commonmark.thephpleague.com/2.1/customization/rendering/
      */
     'inline_renderers' => [
-        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
+        // ['class' => FencedCode::class, 'renderer' => MyCustomCodeRenderer::class, 'priority' => 0]
     ],
 
     /*
@@ -87,6 +87,6 @@ return [
      * More info: https://commonmark.thephpleague.com/2.3/customization/inline-parsing/
      */
     'inline_parsers' => [
-        // ['parser' => new MyCustomInlineParser(), 'priority' => 0]
+        // ['parser' => MyCustomInlineParser::class, 'priority' => 0]
     ],
 ];

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -98,7 +98,7 @@ return [
      * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
     'block_renderers' => [
-        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
+        // ['class' => FencedCode::class, 'renderer' => MyCustomCodeRenderer::class, 'priority' => 0]
     ],
 
     /*
@@ -108,7 +108,17 @@ return [
      * More info: https://commonmark.thephpleague.com/2.0/customization/rendering/
      */
     'inline_renderers' => [
-        // ['class' => FencedCode::class, 'renderer' => new MyCustomCodeRenderer(), 'priority' => 0]
+        // ['class' => FencedCode::class, 'renderer' => MyCustomCodeRenderer::class, 'priority' => 0]
+    ],
+
+    /*
+     * These inline parsers should be added to the markdown environment. A valid
+     * parser implements League\CommonMark\Renderer\InlineParserInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.3/customization/inline-parsing/
+     */
+    'inline_parsers' => [
+        // ['parser' => MyCustomInlineParser::class, 'priority' => 0]
     ],
 ];
 ```

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -129,7 +129,7 @@ class MarkdownRenderer
         return $this->getMarkdownConverter()->convert($markdown);
     }
 
-    private function getClassInstance($class)
+    protected function getClassInstance($class)
     {
         if (is_string($class) && class_exists($class)) {
             $class = new $class();

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -129,6 +129,15 @@ class MarkdownRenderer
         return $this->getMarkdownConverter()->convert($markdown);
     }
 
+    private function getClassInstance($class)
+    {
+        if (is_string($class) && class_exists($class)) {
+            $class = new $class();
+        }
+
+        return $class;
+    }
+
     protected function configureCommonMarkEnvironment(EnvironmentBuilderInterface $environment): void
     {
         $environment->addExtension(new CommonMarkCoreExtension());
@@ -141,22 +150,19 @@ class MarkdownRenderer
         }
 
         foreach ($this->extensions as $extension) {
-            if (is_string($extension) && class_exists($extension)) {
-                $extension = new $extension();
-            }
-            $environment->addExtension($extension);
+            $environment->addExtension($this->getClassInstance($extension));
         }
 
         foreach ($this->blockRenderers as $blockRenderer) {
-            $environment->addRenderer($blockRenderer['class'], $blockRenderer['renderer'], $blockRenderer['priority'] ?? 0);
+            $environment->addRenderer($blockRenderer['class'], $this->getClassInstance($blockRenderer['renderer']), $blockRenderer['priority'] ?? 0);
         }
 
         foreach ($this->inlineRenderers as $inlineRenderer) {
-            $environment->addRenderer($inlineRenderer['class'], $inlineRenderer['renderer'], $inlineRenderer['priority'] ?? 0);
+            $environment->addRenderer($inlineRenderer['class'], $this->getClassInstance($inlineRenderer['renderer']), $inlineRenderer['priority'] ?? 0);
         }
 
         foreach ($this->inlineParsers as $inlineParser) {
-            $environment->addInlineParser($inlineParser['parser'], $inlineParser['priority'] ?? 0);
+            $environment->addInlineParser($this->getClassInstance($inlineParser['parser']), $inlineParser['priority'] ?? 0);
         }
     }
 

--- a/tests/MarkdownInlineParserTest.php
+++ b/tests/MarkdownInlineParserTest.php
@@ -17,3 +17,19 @@ it('can use custom inline parser', function () {
 
     expect($html)->toEqual('<p>I am a text with a very randomly placed THIS-REPLACED-THE-SYMBOL symbol in the middle.</p>' . PHP_EOL);
 });
+
+it('can use custom inline parser class', function () {
+    config()->set('markdown.inline_parsers', [
+        ['parser' => CustomInlineParser::class, 'priority' => 0],
+    ]);
+
+    $markdown = <<<MD
+        I am a text with a very randomly placed @ symbol in the middle.
+       MD;
+
+    $html = markdownRenderer()
+        ->disableAnchors()
+        ->toHtml($markdown);
+
+    expect($html)->toEqual('<p>I am a text with a very randomly placed THIS-REPLACED-THE-SYMBOL symbol in the middle.</p>' . PHP_EOL);
+});

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -64,9 +64,37 @@ it('can register block renderers', function () {
     expect($priorityArray[25][0])->toBeInstanceOf(TextDividerRenderer::class);
 });
 
+it('can register block renderers class', function () {
+    config()->set('markdown.block_renderers', [
+        ['class' => ThematicBreak::class, 'renderer' => TextDividerRenderer::class, 'priority' => 25],
+    ]);
+
+    $renderers = markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
+    $priorityArray = getProtectedPropertyValue($renderers, 'list');
+
+    expect(array_keys($priorityArray)[0])->toEqual(25);
+    expect($priorityArray)->toHaveKey(25);
+    expect($priorityArray[25])->toHaveKey(0);
+    expect($priorityArray[25][0])->toBeInstanceOf(TextDividerRenderer::class);
+});
+
 it('can register inline renderers', function () {
     config()->set('markdown.inline_renderers', [
         ['class' => ThematicBreak::class, 'renderer' => new InlineTextDividerRenderer(), 'priority' => 42],
+    ]);
+
+    $renderers = markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);
+    $priorityArray = getProtectedPropertyValue($renderers, 'list');
+
+    expect(array_keys($priorityArray)[0])->toEqual(42);
+    expect($priorityArray)->toHaveKey(42);
+    expect($priorityArray[42])->toHaveKey(0);
+    expect($priorityArray[42][0])->toBeInstanceOf(InlineTextDividerRenderer::class);
+});
+
+it('can register inline renderers class', function () {
+    config()->set('markdown.inline_renderers', [
+        ['class' => ThematicBreak::class, 'renderer' => InlineTextDividerRenderer::class, 'priority' => 42],
     ]);
 
     $renderers = markdownConverter()->getEnvironment()->getRenderersForClass(ThematicBreak::class);


### PR DESCRIPTION
configuration files are not serializeable when using renderers instances instead of class names

Closes https://github.com/spatie/laravel-markdown/discussions/33#discussioncomment-5742300

> As soon as I convert all of the renderers from new MyRenderer() to MyRenderer::class, the "configuration files are not serializeable" error goes away.
>
>So I think it's caused by adding new instances to the config—or at least, the instances added to the config can't be serialized. This is something that happens with serialized jobs too when they're constructed with data that can't be serialized.
>
>Now though, when I have my renderers like MyRenderer::class, I'm getting this error instead:
> ```
> League\CommonMark\Environment\Environment::addRenderer(): 
>Argument #2 ($renderer) must be of type League\CommonMark\Renderer\NodeRendererInterface,
>string given, called in /app/vendor/spatie/laravel-markdown/src/MarkdownRenderer.php on line 151
> ```