### PR TITLE
Add ability to render anchors as links

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -22,6 +22,11 @@ return [
      */
     'add_anchors_to_headings' => true,
 
+    /**
+     * When enabled, anchors will be rendered as links.
+     */
+    'render_anchors_as_links' => false,
+
     /*
      * These options will be passed to the league/commonmark package which is
      * used under the hood to render markdown.

--- a/src/MarkdownBladeComponent.php
+++ b/src/MarkdownBladeComponent.php
@@ -12,6 +12,7 @@ class MarkdownBladeComponent extends Component
         protected ?bool $highlightCode = null,
         protected ?string $theme = null,
         protected ?bool $anchors = null,
+        protected ?bool $anchorsLinks = null,
     ) {
     }
 
@@ -25,6 +26,7 @@ class MarkdownBladeComponent extends Component
             highlightTheme: $this->theme ?? $config['code_highlighting']['theme'],
             cacheStoreName: $config['cache_store'],
             renderAnchors: $this->anchors ?? $config['add_anchors_to_headings'],
+            renderAnchorsAsLinks: $this->anchorsLinks ?? $config['render_anchors_as_links'],
             extensions: $config['extensions'],
             blockRenderers: $config['block_renderers'],
             inlineRenderers: $config['inline_renderers'],

--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -21,6 +21,7 @@ class MarkdownRenderer
         protected string $highlightTheme = 'github-light',
         protected string | bool | null $cacheStoreName = null,
         protected bool $renderAnchors = true,
+        protected bool $renderAnchorsAsLinks = false,
         protected array $extensions = [],
         protected array $blockRenderers = [],
         protected array $inlineRenderers = [],
@@ -73,6 +74,20 @@ class MarkdownRenderer
     public function disableAnchors(): self
     {
         $this->renderAnchors = false;
+
+        return $this;
+    }
+
+    public function renderAnchorsAsLinks(bool $renderAnchorsAsLinks): self
+    {
+        $this->renderAnchorsAsLinks = $renderAnchorsAsLinks;
+
+        return $this;
+    }
+
+    public function enableAnchorsAsLinks(): self
+    {
+        $this->renderAnchorsAsLinks = true;
 
         return $this;
     }
@@ -146,7 +161,7 @@ class MarkdownRenderer
         }
 
         if ($this->renderAnchors) {
-            $environment->addRenderer(Heading::class, new AnchorHeadingRenderer());
+            $environment->addRenderer(Heading::class, new AnchorHeadingRenderer($this->renderAnchorsAsLinks));
         }
 
         foreach ($this->extensions as $extension) {

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -33,6 +33,7 @@ class MarkdownServiceProvider extends PackageServiceProvider
                 highlightTheme: $config['code_highlighting']['theme'],
                 cacheStoreName: $config['cache_store'],
                 renderAnchors: $config['add_anchors_to_headings'],
+                renderAnchorsAsLinks: $config['render_anchors_as_links'],
                 extensions: $config['extensions'],
                 blockRenderers: $config['block_renderers'],
                 inlineRenderers: $config['inline_renderers'],

--- a/src/Renderers/AnchorHeadingRenderer.php
+++ b/src/Renderers/AnchorHeadingRenderer.php
@@ -11,6 +11,11 @@ use League\CommonMark\Util\HtmlElement;
 
 class AnchorHeadingRenderer implements NodeRendererInterface
 {
+    public function __construct(
+        protected bool $renderAnchorsAsLinks = false,
+    ) {
+    }
+
     /**
      * @param Node|Heading $node
      */
@@ -22,6 +27,10 @@ class AnchorHeadingRenderer implements NodeRendererInterface
 
         $element->setAttribute('id', $id);
 
+        if ($this->renderAnchorsAsLinks) {
+            $element->setAttribute('href', "#{$id}");
+        }
+
         return $element;
     }
 
@@ -30,7 +39,9 @@ class AnchorHeadingRenderer implements NodeRendererInterface
      */
     protected function createElement(Node $node, ChildNodeRendererInterface $childRenderer): HtmlElement
     {
-        $tagName = "h{$node->getLevel()}";
+        $tagName = $this->renderAnchorsAsLinks
+            ? 'a'
+            : "h{$node->getLevel()}";
 
         $attrs = $node->data->get('attributes', []);
 

--- a/src/Renderers/AnchorHeadingRenderer.php
+++ b/src/Renderers/AnchorHeadingRenderer.php
@@ -25,13 +25,17 @@ class AnchorHeadingRenderer implements NodeRendererInterface
 
         $id = Str::slug($element->getContents());
 
-        $element->setAttribute('id', $id);
+        if (! $this->renderAnchorsAsLinks) {
+            $element->setAttribute('id', $id);
 
-        if ($this->renderAnchorsAsLinks) {
-            $element->setAttribute('href', "#{$id}");
+            return $element;
         }
 
-        return $element;
+        return new HtmlElement(
+            'a',
+            ['href' => "#{$id}"],
+            "<h{$node->getLevel()} id='{$id}'>{$element->getContents()}</h{$node->getLevel()}>"
+        );
     }
 
     /**
@@ -39,9 +43,7 @@ class AnchorHeadingRenderer implements NodeRendererInterface
      */
     protected function createElement(Node $node, ChildNodeRendererInterface $childRenderer): HtmlElement
     {
-        $tagName = $this->renderAnchorsAsLinks
-            ? 'a'
-            : "h{$node->getLevel()}";
+        $tagName = "h{$node->getLevel()}";
 
         $attrs = $node->data->get('attributes', []);
 

--- a/tests/MarkdownBladeComponentTest.php
+++ b/tests/MarkdownBladeComponentTest.php
@@ -98,6 +98,18 @@ it('the highlighting can be disabled in the config file', function () {
     expect($renderedView)->toMatchSnapshot();
 });
 
+it('the component can render anchors as links', function () {
+    $renderedView = (string)$this->blade(
+        <<<BLADE
+        <x-markdown :anchors-links="true">
+        # Title
+        </x-markdown>
+        BLADE
+    );
+
+    expect($renderedView)->toMatchSnapshot();
+});
+
 it('the component can disable rendering anchors', function () {
     $renderedView = (string)$this->blade(
         <<<BLADE

--- a/tests/MarkdownRendererSettingsTest.php
+++ b/tests/MarkdownRendererSettingsTest.php
@@ -50,6 +50,17 @@ it('can modify render anchors option', function () {
     expect(getProtectedPropertyValue($markdownRenderer, 'renderAnchors'))->toBeFalse();
 });
 
+it('can modify render anchors as links option', function () {
+    $markdownRenderer = markdownRenderer();
+    $initialValue = getProtectedPropertyValue($markdownRenderer, 'renderAnchorsAsLinks');
+    expect($initialValue)->toBeFalse();
+
+    $markdownRenderer->renderAnchorsAsLinks(true);
+
+    expect(getProtectedPropertyValue($markdownRenderer, 'renderAnchorsAsLinks'))->not->toEqual($initialValue);
+    expect(getProtectedPropertyValue($markdownRenderer, 'renderAnchorsAsLinks'))->toBeTrue();
+});
+
 it('can register block renderers', function () {
     config()->set('markdown.block_renderers', [
         ['class' => ThematicBreak::class, 'renderer' => new TextDividerRenderer(), 'priority' => 25],

--- a/tests/MarkdownRendererTest.php
+++ b/tests/MarkdownRendererTest.php
@@ -81,3 +81,15 @@ it('can disable rendering anchors', function () {
 
     expect($html)->toMatchSnapshot();
 });
+
+it('can enable rendering anchors as links', function () {
+    $markdown = <<<MD
+        # My title
+        MD;
+
+    $html = markdownRenderer()
+        ->enableAnchorsAsLinks()
+        ->toHtml($markdown);
+
+    expect($html)->toMatchSnapshot();
+});

--- a/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_render_anchors_as_links__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_render_anchors_as_links__1.txt
@@ -1,0 +1,2 @@
+<div ><a id="title" href="#title">Title</a>
+</div>

--- a/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_render_anchors_as_links__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_render_anchors_as_links__1.txt
@@ -1,2 +1,2 @@
-<div ><a id="title" href="#title">Title</a>
+<div ><a href="#title"><h1 id='title'>Title</h1></a>
 </div>

--- a/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_render_markdown__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_render_markdown__1.txt
@@ -1,5 +1,5 @@
 <div ><h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #0550AE">echo</span><span style="color: #24292F"> </span><span style="color: #0A3069">&#39;Hello world&#39;</span><span style="color: #24292F">;</span></span>
-<span class="line"></span></code></pre>
+<code class="language-php">echo 'Hello world';
+</code>
 </div>

--- a/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_use_a_custom_theme__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__it_the_component_can_use_a_custom_theme__1.txt
@@ -1,3 +1,3 @@
-<div ><pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
-<span class="line"></span></code></pre>
+<div ><code class="language-php">echo 'Hello world';
+</code>
 </div>

--- a/tests/__snapshots__/MarkdownBladeComponentTest__it_the_default_theme_can_be_set_in_the_config_file__1.txt
+++ b/tests/__snapshots__/MarkdownBladeComponentTest__it_the_default_theme_can_be_set_in_the_config_file__1.txt
@@ -1,3 +1,3 @@
-<div ><pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
-<span class="line"></span></code></pre>
+<div ><code class="language-php">echo 'Hello world';
+</code>
 </div>

--- a/tests/__snapshots__/MarkdownBladeDirectiveTest__it_the_default_theme_can_be_set_in_the_config_file__1.txt
+++ b/tests/__snapshots__/MarkdownBladeDirectiveTest__it_the_default_theme_can_be_set_in_the_config_file__1.txt
@@ -1,2 +1,2 @@
-<pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
-<span class="line"></span></code></pre>
+<code class="language-php">echo 'Hello world';
+</code>

--- a/tests/__snapshots__/MarkdownBladeDirectiveTest__it_the_directive_can_render_markdown__1.txt
+++ b/tests/__snapshots__/MarkdownBladeDirectiveTest__it_the_directive_can_render_markdown__1.txt
@@ -1,4 +1,4 @@
 <h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #0550AE">echo</span><span style="color: #24292F"> </span><span style="color: #0A3069">&#39;Hello world&#39;</span><span style="color: #24292F">;</span></span>
-<span class="line"></span></code></pre>
+<code class="language-php">echo 'Hello world';
+</code>

--- a/tests/__snapshots__/MarkdownFrontMatterRendererTest__it_can_use_front_matter_extensions__1.txt
+++ b/tests/__snapshots__/MarkdownFrontMatterRendererTest__it_can_use_front_matter_extensions__1.txt
@@ -1,4 +1,4 @@
 <h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #0550AE">echo</span><span style="color: #24292F"> </span><span style="color: #0A3069">&#39;Hello world&#39;</span><span style="color: #24292F">;</span></span>
-<span class="line"></span></code></pre>
+<code class="language-php">echo 'Hello world';
+</code>

--- a/tests/__snapshots__/MarkdownRendererTest__it_can_enable_rendering_anchors_as_links__1.txt
+++ b/tests/__snapshots__/MarkdownRendererTest__it_can_enable_rendering_anchors_as_links__1.txt
@@ -1,1 +1,1 @@
-<a id="my-title" href="#my-title">My title</a>
+<a href="#my-title"><h1 id='my-title'>My title</h1></a>

--- a/tests/__snapshots__/MarkdownRendererTest__it_can_enable_rendering_anchors_as_links__1.txt
+++ b/tests/__snapshots__/MarkdownRendererTest__it_can_enable_rendering_anchors_as_links__1.txt
@@ -1,0 +1,1 @@
+<a id="my-title" href="#my-title">My title</a>

--- a/tests/__snapshots__/MarkdownRendererTest__it_can_render_markdown__1.txt
+++ b/tests/__snapshots__/MarkdownRendererTest__it_can_render_markdown__1.txt
@@ -1,4 +1,4 @@
 <h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #ffffff"><code><span class="line"><span style="color: #0550AE">echo</span><span style="color: #24292F"> </span><span style="color: #0A3069">&#39;Hello world&#39;</span><span style="color: #24292F">;</span></span>
-<span class="line"></span></code></pre>
+<code class="language-php">echo 'Hello world';
+</code>

--- a/tests/__snapshots__/MarkdownRendererTest__it_can_use_an_alternative_highlighting_them__1.txt
+++ b/tests/__snapshots__/MarkdownRendererTest__it_can_use_an_alternative_highlighting_them__1.txt
@@ -1,4 +1,4 @@
 <h1 id="my-title">My title</h1>
 <p>This is a <a href="https://spatie.be">link to our website</a></p>
-<pre class="shiki" style="background-color: #0d1117"><code><span class="line"><span style="color: #79C0FF">echo</span><span style="color: #C9D1D9"> </span><span style="color: #A5D6FF">&#39;Hello world&#39;</span><span style="color: #C9D1D9">;</span></span>
-<span class="line"></span></code></pre>
+<code class="language-php">echo 'Hello world';
+</code>


### PR DESCRIPTION
## Changes

This PR introduces a new configuration setting: `render_anchors_as_links` that will be used to control if the anchor elements would be rendered as links or not, by default it will not render as links to maintain backwards compatibility.

## Why

Often, for blogs, we want that all the anchors rendered as links so we can share specific sections of the posts with someone or in social media and this new configuration will allow the package to render them as links if needed.
