### PR TITLE
Update deprecated function 'convertToHtml' to 'convert' function

### DIFF
--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -203,6 +203,6 @@ class MarkdownRenderer
 
     public function convertToHtml(string $markdown): RenderedContentInterface
     {
-        return $this->getMarkdownConverter()->convertToHtml($markdown);
+        return $this->getMarkdownConverter()->convert($markdown);
     }
 }


### PR DESCRIPTION
## Changes
This PR updates `convertToHtml` function to `convert` function with same params.
 
## Why
Since thephpleague updates commonmark [version 2.4](https://github.com/thephpleague/commonmark/commit/6bd1ef862faaa8646a1faf55c4dd762ff5e1358a) package they updates `MarkdownConverter` class by make `convertToHtml` deprecated and use `convert` function.