### PR TITLE
Fix breaking change cache duration

### DIFF
--- a/src/MarkdownRenderer.php
+++ b/src/MarkdownRenderer.php
@@ -129,10 +129,12 @@ class MarkdownRenderer
 
         $cacheKey = $this->getCacheKey($markdown);
 
-        if($this->cacheDuration === null) {
-            return cache()->rememberForever($cacheKey, function () use ($markdown) {
-                return $this->convertMarkdownToHtml($markdown);
-            });
+        if ($this->cacheDuration === null) {
+            return cache()
+                ->store($this->cacheStoreName)
+                ->rememberForever($cacheKey, function () use ($markdown) {
+                    return $this->convertMarkdownToHtml($markdown);
+                });
         }
 
         return cache()


### PR DESCRIPTION
PR #76 caused a breaking change as it no longer set the cache store correctly. While using the null cache store with a cache duration of null, loading a page with markdown on it causes a `BadMethodCallException: This cache store does not support tagging.` error.

This PR includes the missing `store()` method that is also used in the default return statement.