### PR TITLE
Add test confirming footnotes render via the FootnoteExtension

### DIFF
--- a/tests/MarkdownRendererTest.php
+++ b/tests/MarkdownRendererTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use League\CommonMark\Extension\Footnote\FootnoteExtension;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 
 it('can render markdown', function () {
@@ -32,6 +33,27 @@ it('can use extensions', function () {
         ->toHtml($markdown);
 
     expect($html)->toMatchSnapshot();
+});
+
+it('can render footnotes using the footnote extension', function () {
+    config()->set('markdown.extensions', [
+        new FootnoteExtension(),
+    ]);
+
+    $markdown = <<<MD
+        Here is a footnote reference.[^1]
+
+        [^1]: Here is the footnote.
+        MD;
+
+    $html = markdownRenderer()
+        ->disableAnchors()
+        ->toHtml($markdown);
+
+    expect($html)
+        ->toContain('class="footnote-ref"')
+        ->toContain('id="fn:1"')
+        ->toContain('Here is the footnote.');
 });
 
 it('can disable highlighting', function () {


### PR DESCRIPTION
Discussion #98 asked whether the package supports Markdown footnotes/citations.

It does. Footnotes work out of the box by registering CommonMark's built-in `FootnoteExtension` (shipped with `league/commonmark`, no extra dependency) through the package's `extensions` config.

This adds a test confirming that. It registers the extension via `markdown.extensions` and asserts the rendered HTML contains the footnote reference link, the footnote definition anchor, and the footnote content.

The test uses explicit `toContain` assertions rather than a snapshot, so it documents the expected footnote markup directly and stays portable across snapshot-driver versions.

Note on "citations": CommonMark has no native citation syntax (like Pandoc's `[@key]`). What's available is footnotes; bibliographic citations would need a custom extension.